### PR TITLE
Add missing functions to emscripten EGL implementation

### DIFF
--- a/src/video/emscripten/SDL_emscriptenopengles.c
+++ b/src/video/emscripten/SDL_emscriptenopengles.c
@@ -60,6 +60,8 @@ Emscripten_GLES_LoadLibrary(_THIS, const char *path) {
     LOAD_FUNC(eglWaitNative);
     LOAD_FUNC(eglWaitGL);
     LOAD_FUNC(eglBindAPI);
+    LOAD_FUNC(eglQueryString);
+    LOAD_FUNC(eglGetError);
     
     _this->egl_data->egl_display = _this->egl_data->eglGetDisplay(EGL_DEFAULT_DISPLAY);
     if (!_this->egl_data->egl_display) {


### PR DESCRIPTION
In the latest version of SDL, two new functions were added to EGL interface,
which are already present in the Emscripten javascript implementation of the EGL
library, however they are not registered in the C interface, which leads to call on the
wrong pointer (which is caught in Emscripten via call to abort()).

This commit properly registers new functions so that they can be used on Emscripten.